### PR TITLE
fix: remove epoc list by area and add id_area filter to main epoc API

### DIFF
--- a/backend/app/core/prospecting/actions.py
+++ b/backend/app/core/prospecting/actions.py
@@ -211,7 +211,7 @@ class AreaDashboardActions(BaseReadOnlyActions[AreaDashboard]):
 
         return q.all()
 
-    def get_intersected_areas(self, db: Session, id_area: int, type_code: str) -> Query:
+    def get_intersected_areas(self, db: Session, id_area: int, type_code: str) -> List:
         """[summary]
 
         Args:
@@ -246,22 +246,28 @@ class AreaDashboardActions(BaseReadOnlyActions[AreaDashboard]):
 
 class EpocActions(BaseReadOnlyActions[Epoc]):
     def get_epocs(
-        self, db: Session, status: Optional[str] = None, envelope: Optional[List] = None
-    ) -> Query:
+        self,
+        db: Session,
+        id_area: Optional[int] = None,
+        status: Optional[str] = None,
+        envelope: Optional[List] = None,
+    ) -> List:
         """[summary]
 
         Args:
-            db (Session): [description]
-            envelope (Optional[List], optional): [description]. Defaults to None.
+            db (Session): DB Session
+            envelope (Optional[List], optional): Filtering by bounding box. Defaults to None.
+            id_area (Optional[int], optional): Filtering by area. Defaults to None.
+            status (Optional[str], optional): Filtering by status. Defaults to None
 
         Returns:
-            Query: [description]
+            Query: Return
         """
         q = db.query(
             Epoc.id_epoc, Epoc.id_ff, Epoc.status, Epoc.rang_rsv, Epoc.geojson.label("geometry")
         )
         q = q.filter(Epoc.status == status) if status else q
-
+        q = q.filter(Epoc.id_area == id_area) if id_area else q
         q = (
             q.filter(
                 functions.ST_Intersects(
@@ -274,7 +280,7 @@ class EpocActions(BaseReadOnlyActions[Epoc]):
             if envelope
             else q
         )
-
+        logger.debug(f"Query ALL type {type(q.all())}")
         return q.all()
 
 

--- a/backend/app/core/prospecting/routers.py
+++ b/backend/app/core/prospecting/routers.py
@@ -152,22 +152,22 @@ def area_list_intersected_areas(
     return q
 
 
-@router.get(
-    "/area/list_epocs/{id_area}",
-    response_model=List[EpocFeaturePropertiesSchema],
-    tags=["prospecting"],
-    summary="...",
-    description="""cqfd""",
-)
-def area_list_epocs(
-    id_area: int,
-    db: Session = Depends(get_db),
-) -> Any:
-    q = area_dashboard.get_area_epocs(db=db, id_area=id_area)
-    logger.debug(q)
-    if not q:
-        raise HTTPException(status_code=404, detail="Data not found")
-    return q
+# @router.get(
+#     "/area/list_epocs/{id_area}",
+#     response_model=List[EpocFeaturePropertiesSchema],
+#     tags=["prospecting"],
+#     summary="...",
+#     description="""cqfd""",
+# )
+# def area_list_epocs(
+#     id_area: int,
+#     db: Session = Depends(get_db),
+# ) -> Any:
+#     q = area_dashboard.get_area_epocs(db=db, id_area=id_area)
+#     logger.debug(q)
+#     if not q:
+#         raise HTTPException(status_code=404, detail="Data not found")
+#     return q
 
 
 @router.get(
@@ -187,12 +187,13 @@ Status can be optionaly optionally using the query string `status=...` . status 
 def epoc_list(
     db: Session = Depends(get_db),
     status: Optional[str] = None,
+    id_area: Optional[int] = None,
     envelope: Optional[str] = None,
 ) -> Any:
     start_time = time.time()
     envelope = [float(c) for c in envelope.split(",")] if envelope else None
     logger.debug(f"STATUS {status}")
-    epocs = epoc.get_epocs(db=db, envelope=envelope, status=status)
+    epocs = epoc.get_epocs(db=db, envelope=envelope, status=status, id_area=id_area)
     features = []
     if len(epocs) == 0:
         HTTPException(status_code=404, detail="Data not found")

--- a/backend/app/core/prospecting/schemas.py
+++ b/backend/app/core/prospecting/schemas.py
@@ -11,11 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class AreaKnowledgeLevelDetailSchema(BaseModel):
-    """[summary]
-
-    Args:
-        BaseModel ([type]): [description]
-    """
+    """[AreaKnowledgeLevel] Data schema for area > period detail"""
 
     old_count: Union[None, int]
     new_count: Union[None, int]
@@ -23,11 +19,7 @@ class AreaKnowledgeLevelDetailSchema(BaseModel):
 
 
 class AreaKnowledgeLevelPropertiesSchema(BaseModel):
-    """[summary]
-
-    Args:
-        BaseModel ([type]): [description]
-    """
+    """[AreaKnowledgeLevel] Data schema for area detail"""
 
     area_name: str
     area_code: str
@@ -40,11 +32,7 @@ class AreaKnowledgeLevelPropertiesSchema(BaseModel):
 
 
 class AreaKnowledgeLevelFeatureSchema(Feature):
-    """[summary]
-
-    Args:
-        Feature ([type]): [description]
-    """
+    """[AreaKnowledgeLevel] AreaKnowledgeLevelPropertiesSchema as GeoJson properties"""
 
     properties: AreaKnowledgeLevelPropertiesSchema
 
@@ -129,7 +117,10 @@ class AreaDashboardSchema(BaseModel):
 
 
 class AreaDashboardTimeDistribSchema(BaseModel):
-    """[summary]
+    """[AreaDashboard] Schema for data time distribution
+
+    * label: value label
+    * count_data: value
 
     Args:
         BaseModel ([type]): [description]


### PR DESCRIPTION
fix #72 
Epoc in area can now be listed in geojson format, using main EPOC search API `/api/v1/epoc?id_area=xxx`