### PR TITLE
Fix #352 - News title missing on landing page

### DIFF
--- a/frontend/components/home/NewsSection.vue
+++ b/frontend/components/home/NewsSection.vue
@@ -253,7 +253,7 @@ h5.Subtitle {
 
 .CardTitle {
   max-height: 48px;
-  overflow-y: hidden;
+  /*overflow-y: hidden;*/
 }
 
 .CardBlurring {


### PR DESCRIPTION
Restore news title display on news list in landing page (fix #352)